### PR TITLE
Table name changed.

### DIFF
--- a/src/models/base/Html.php
+++ b/src/models/base/Html.php
@@ -22,7 +22,7 @@ abstract class Html extends \yii\db\ActiveRecord
      */
     public static function tableName()
     {
-        return 'app_html';
+        return '{{%html}}';
     }
 
     /**


### PR DESCRIPTION
In my case during migration table named "html" without prefix "app" was created. I think it should consider it like in your migration.
