### PR TITLE
stylelint

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -18,6 +18,11 @@ class Module extends \yii\base\Module
     private $_view;
 
     /**
+     * @var bool enable/disable stylelint lint and fix
+     */
+    public $enableLessLinting = false;
+
+    /**
      * @param Action $action
      *
      * @return bool

--- a/src/controllers/base/LessController.php
+++ b/src/controllers/base/LessController.php
@@ -96,18 +96,27 @@ class LessController extends Controller
     public function actionUpdate($id)
     {
         $model = $this->findModel($id);
-        if ($model->load($_POST) && $model->save()) {
+        if ($model->load(Yii::$app->request->post()) && $model->save()) {
             Yii::$app->session->addFlash('success', 'Record has been updated');
-            if (ArrayHelper::getValue($_POST, 'subaction') === 'lint') {
-                $model->lintLess();
+
+            if ($this->module->enableLessLinting) {
+                if (Yii::$app->request->post('subaction') === 'lint') {
+                    $model->lintLess();
+                    if (empty($model->lintErrors)) {
+                        return $this->refresh();
+                    }
+                }
+                if (Yii::$app->request->post('subaction') === 'fix') {
+                    $model->lintLess(true);
+                    $model->value = $model->fixedValue;
+                    if ($model->save()) {
+                        return $this->refresh();
+                    }
+                }
             }
-            if (ArrayHelper::getValue($_POST, 'subaction') === 'fix') {
-                $model->lintLess(true);
-                $model->value = $model->fixedValue;
-                $model->save();
-            }
-            if (ArrayHelper::getValue($_POST, 'subaction') === 'save') {
-                return $this->redirect(Url::previous());
+
+            if (Yii::$app->request->post('subaction') === 'save') {
+                return $this->redirect(['index']);
             }
         }
         return $this->render(

--- a/src/controllers/base/LessController.php
+++ b/src/controllers/base/LessController.php
@@ -98,8 +98,16 @@ class LessController extends Controller
         $model = $this->findModel($id);
         if ($model->load($_POST) && $model->save()) {
             Yii::$app->session->addFlash('success', 'Record has been updated');
-            if (ArrayHelper::getValue($_POST, 'subaction') != 'apply') {
-                return $this->redirect(['view', 'id' => $model->id]);
+            if (ArrayHelper::getValue($_POST, 'subaction') === 'lint') {
+                $model->lintLess();
+            }
+            if (ArrayHelper::getValue($_POST, 'subaction') === 'fix') {
+                $model->lintLess(true);
+                $model->value = $model->fixedValue;
+                $model->save();
+            }
+            if (ArrayHelper::getValue($_POST, 'subaction') === 'save') {
+                return $this->redirect(Url::previous());
             }
         }
         return $this->render(

--- a/src/views/less/_form.php
+++ b/src/views/less/_form.php
@@ -90,35 +90,37 @@ use yii\helpers\Html;
             );
             ?>
 
-            <?= Html::submitButton(
-                FA::icon(FA::_SAVE) . ' '.
-                Yii::t('prototype', 'Lint'),
-                [
-                    'id' => 'apply-'.$model->formName(),
-                    'name' => 'subaction',
-                    'value' => 'lint',
-                    'class' => 'btn btn-success',
-                ]
-            );
-            ?>
+            <?php if ($this->context->module->enableLessLinting): ?>
+                <?= Html::submitButton(
+                    FA::icon(FA::_SAVE) . ' '.
+                    Yii::t('prototype', 'Lint'),
+                    [
+                        'id' => 'apply-'.$model->formName(),
+                        'name' => 'subaction',
+                        'value' => 'lint',
+                        'class' => 'btn btn-success',
+                    ]
+                );
+                ?>
 
-            <?= Html::submitButton(
-                FA::icon(FA::_SAVE) . ' '.
-                Yii::t('prototype', 'Fix'),
-                [
-                    'id' => 'apply-'.$model->formName(),
-                    'name' => 'subaction',
-                    'value' => 'fix',
-                    'class' => 'btn btn-success',
-                ]
-            );
-            ?>
+                <?= Html::submitButton(
+                    FA::icon(FA::_SAVE) . ' '.
+                    Yii::t('prototype', 'Fix'),
+                    [
+                        'id' => 'apply-'.$model->formName(),
+                        'name' => 'subaction',
+                        'value' => 'fix',
+                        'class' => 'btn btn-success',
+                    ]
+                );
+                ?>
+            <?php endif ?>
 
         <?php endif ?>
 
         <?php ActiveForm::end(); ?>
 
-        <?php if (!empty($model->lintErrors)): ?>
+        <?php if (!empty($model->lintErrors) && $this->context->module->enableLessLinting): ?>
             <h2><?= Yii::t('prototype', 'Lint errors')?></h2>
             <pre><?= $model->lintErrors; ?></pre>
         <?php endif ?>

--- a/src/views/less/_form.php
+++ b/src/views/less/_form.php
@@ -43,7 +43,7 @@ use yii\helpers\Html;
             <?= $form->field($model, 'key')->textInput(['maxlength' => true]) ?>
             <?= $form->field($model, 'value')
                 ->widget(AceEditor::class,
-                    ['mode' => 'less', 'container_options' => ['style' => 'height: 50vh']]) ?>
+                    ['mode' => 'less', 'plugin_options' => ['tabSize' => 2], 'container_options' => ['style' => 'height: 50vh']]) ?>
         </p>
         <?php $this->endBlock(); ?>
 
@@ -70,6 +70,8 @@ use yii\helpers\Html;
             ($model->isNewRecord ? Yii::t('prototype', 'Create') : Yii::t('prototype', 'Save')),
             [
                 'id' => 'save-'.$model->formName(),
+                'name' => 'subaction',
+                'value' => 'save',
                 'class' => 'btn btn-success',
             ]
         );
@@ -87,9 +89,39 @@ use yii\helpers\Html;
                 ]
             );
             ?>
+
+            <?= Html::submitButton(
+                FA::icon(FA::_SAVE) . ' '.
+                Yii::t('prototype', 'Lint'),
+                [
+                    'id' => 'apply-'.$model->formName(),
+                    'name' => 'subaction',
+                    'value' => 'lint',
+                    'class' => 'btn btn-success',
+                ]
+            );
+            ?>
+
+            <?= Html::submitButton(
+                FA::icon(FA::_SAVE) . ' '.
+                Yii::t('prototype', 'Fix'),
+                [
+                    'id' => 'apply-'.$model->formName(),
+                    'name' => 'subaction',
+                    'value' => 'fix',
+                    'class' => 'btn btn-success',
+                ]
+            );
+            ?>
+
         <?php endif ?>
 
         <?php ActiveForm::end(); ?>
+
+        <?php if (!empty($model->lintErrors)): ?>
+            <h2><?= Yii::t('prototype', 'Lint errors')?></h2>
+            <pre><?= $model->lintErrors; ?></pre>
+        <?php endif ?>
 
     </div>
 


### PR DESCRIPTION
- Added lint button
- Added fix button
- warning messages if stylelint or stylelint-config-standard are not installed (does not break if not)

- `RUN npm install -g stylelint stylelint-config-standard` musst be added in Dockerfile

after lint

<img width="1146" alt="Bildschirmfoto 2020-04-06 um 14 41 04" src="https://user-images.githubusercontent.com/13135260/78559506-c8194600-7814-11ea-8fd0-06f662102b60.png">

after automatic fix

<img width="1088" alt="Bildschirmfoto 2020-04-06 um 14 41 25" src="https://user-images.githubusercontent.com/13135260/78559530-d10a1780-7814-11ea-8136-1fd9ab597edc.png">

after manual fix

<img width="1031" alt="Bildschirmfoto 2020-04-06 um 14 41 45" src="https://user-images.githubusercontent.com/13135260/78559566-dff0ca00-7814-11ea-8ed1-911c56911dc7.png">

Worth knowing:
- the default config helps editors to not waste time in little fixes
- config can also be customized in settings
- prefer /* */ instead of //
- less functions (mixings) can confuse stylelint but in general works nice