### PR TITLE
Optimize prototype\models\Edit::save()

### DIFF
--- a/src/models/Edit.php
+++ b/src/models/Edit.php
@@ -126,6 +126,13 @@ class Edit extends Model
 				$model->key = $this->keys[$modelId];
 				$model->value = $this->values[$modelId];
 
+                // save only if anything changed to prevent unnecessary validation and saving which can be expensive
+                // (eg. each less will be compiled while validate)
+                if (!$model->getIsNewRecord() && empty($model->getDirtyAttributes())) {
+                    Yii::debug('Nothing changed in model id: ' . $model->id . ' -> continue', __METHOD__);
+                    continue;
+                }
+
 				if ($model->save() === false) {
 					$transaction->rollBack();
 					return false;


### PR DESCRIPTION
## Problem:

If someone has several tabs open in the editor and then triggers [Save], all tabs (models) are transferred to the server for saving.

If the models are less-es, then for each less a validate and a compile is done, which takes a long time and can lead to timeouts. (see: src/models/Less.php#L53)

## Change:

This patch improves this behavior as much as possible by checking each model in prototype\models\Edit::save() to see if anything needs to be saved at all.

Only new or changed models are validated and saved anymore.