### PR TITLE
TimestampBehavior for twig, less and html models

### DIFF
--- a/src/migrations/m211116_101347_add_timestamp_cols.php
+++ b/src/migrations/m211116_101347_add_timestamp_cols.php
@@ -1,0 +1,22 @@
+<?php
+
+use yii\db\Migration;
+
+class m211116_101347_add_timestamp_cols extends Migration
+{
+    public function up()
+    {
+        $this->addColumn('{{%twig}}', 'created_at', $this->dateTime()->null());
+        $this->addColumn('{{%twig}}', 'updated_at', $this->dateTime()->null());
+        $this->addColumn('{{%less}}', 'created_at', $this->dateTime()->null());
+        $this->addColumn('{{%less}}', 'updated_at', $this->dateTime()->null());
+        $this->addColumn('{{%html}}', 'created_at', $this->dateTime()->null());
+        $this->addColumn('{{%html}}', 'updated_at', $this->dateTime()->null());
+    }
+
+    public function down()
+    {
+        echo "m211116_101347_add_timestamp_cols cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/models/BaseModel.php
+++ b/src/models/BaseModel.php
@@ -10,9 +10,12 @@
 namespace dmstr\modules\prototype\models;
 
 
+use bedezign\yii2\audit\AuditTrailBehavior;
 use Yii;
+use yii\behaviors\TimestampBehavior;
 use yii\db\ActiveQuery;
 use yii\db\ActiveRecord;
+use yii\db\Expression;
 
 /**
  * @package dmstr\modules\prototype\models
@@ -20,6 +23,38 @@ use yii\db\ActiveRecord;
  */
 class BaseModel extends ActiveRecord
 {
+
+    /**
+     * Column attribute 'created_at'
+     */
+    const ATTR_CREATED_AT = 'created_at';
+
+    /**
+     * Column attribute 'updated_at'
+     */
+    const ATTR_UPDATED_AT = 'updated_at';
+
+    /**
+     * @inheritdoc
+     *
+     * Use yii\behaviors\TimestampBehavior for created_at and updated_at attribute
+     *
+     * @return array
+     */
+    public function behaviors()
+    {
+
+        $behaviors = parent::behaviors();
+
+        $behaviors['timestamp'] = [
+            'class'              => TimestampBehavior::class,
+            'createdAtAttribute' => static::ATTR_CREATED_AT,
+            'updatedAtAttribute' => static::ATTR_UPDATED_AT,
+            'value'              => new Expression('NOW()'),
+        ];
+        return $behaviors;
+    }
+
     /**
      * @inheritdoc
      */

--- a/src/views/html/index.php
+++ b/src/views/html/index.php
@@ -1,5 +1,6 @@
 <?php
 
+use dmstr\modules\prototype\models\BaseModel;
 use rmrevin\yii\fontawesome\FA;
 use yii\bootstrap\ButtonDropdown;
 use yii\grid\GridView;
@@ -103,6 +104,8 @@ $this->params['breadcrumbs'][] = $this->title;
                         'contentOptions' => ['nowrap' => 'nowrap'],
                     ],
                     'key',
+                    BaseModel::ATTR_UPDATED_AT,
+                    BaseModel::ATTR_CREATED_AT,
                 ],
             ]
         ); ?>

--- a/src/views/html/view.php
+++ b/src/views/html/view.php
@@ -1,6 +1,7 @@
 <?php
 
 use dmstr\bootstrap\Tabs;
+use dmstr\modules\prototype\models\BaseModel;
 use rmrevin\yii\fontawesome\FA;
 use yii\helpers\Html;
 use yii\widgets\DetailView;
@@ -79,6 +80,8 @@ $this->params['breadcrumbs'][] = Yii::t('prototype', 'View');
                 'id',
                 'key',
                 'value:html',
+                BaseModel::ATTR_UPDATED_AT,
+                BaseModel::ATTR_CREATED_AT,
             ],
         ]
     ); ?>

--- a/src/views/less/index.php
+++ b/src/views/less/index.php
@@ -1,5 +1,6 @@
 <?php
 
+use dmstr\modules\prototype\models\BaseModel;
 use rmrevin\yii\fontawesome\FA;
 use yii\bootstrap\ButtonDropdown;
 use yii\grid\GridView;
@@ -103,6 +104,8 @@ $this->params['breadcrumbs'][] = $this->title;
                         'contentOptions' => ['nowrap' => 'nowrap'],
                     ],
                     'key',
+                    BaseModel::ATTR_UPDATED_AT,
+                    BaseModel::ATTR_CREATED_AT,
                 ],
             ]
         ); ?>

--- a/src/views/less/view.php
+++ b/src/views/less/view.php
@@ -1,6 +1,7 @@
 <?php
 
 use dmstr\bootstrap\Tabs;
+use dmstr\modules\prototype\models\BaseModel;
 use rmrevin\yii\fontawesome\FA;
 use yii\helpers\Html;
 use yii\widgets\DetailView;
@@ -83,6 +84,8 @@ $this->params['breadcrumbs'][] = Yii::t('prototype', 'View');
                     'format'    => 'html',
                     'value'     => '<pre>' . Html::encode($model->value) . '</pre>'
                 ],
+                BaseModel::ATTR_UPDATED_AT,
+                BaseModel::ATTR_CREATED_AT,
             ],
         ]
     ); ?>

--- a/src/views/twig/index.php
+++ b/src/views/twig/index.php
@@ -1,5 +1,6 @@
 <?php
 
+use dmstr\modules\prototype\models\BaseModel;
 use rmrevin\yii\fontawesome\FA;
 use yii\grid\GridView;
 use yii\helpers\Html;
@@ -72,6 +73,8 @@ $this->params['breadcrumbs'][] = $this->title;
                     'contentOptions' => ['nowrap' => 'nowrap'],
                 ],
                 'key',
+                BaseModel::ATTR_UPDATED_AT,
+                BaseModel::ATTR_CREATED_AT,
             ],
         ]); ?>
     </div>

--- a/src/views/twig/view.php
+++ b/src/views/twig/view.php
@@ -1,6 +1,7 @@
 <?php
 
 use dmstr\bootstrap\Tabs;
+use dmstr\modules\prototype\models\BaseModel;
 use rmrevin\yii\fontawesome\FA;
 use yii\helpers\Html;
 use yii\widgets\DetailView;
@@ -75,6 +76,8 @@ $this->params['breadcrumbs'][] = Yii::t('prototype', 'View');
                 'format' => 'raw',
                 'value' => "<pre>" . htmlspecialchars($model->value) . "</pre>",
             ],
+            BaseModel::ATTR_UPDATED_AT,
+            BaseModel::ATTR_CREATED_AT,
         ],
     ]); ?>
 


### PR DESCRIPTION
This PR adds the created_at && updated_at table cols and attach [yii\behaviors\TimestampBehavior](https://www.yiiframework.com/doc/api/2.0/yii-behaviors-timestampbehavior) via BaseModel for twig, less and html models.
