### PR TITLE
Export filehandling fixed

### DIFF
--- a/src/commands/PrototypeController.php
+++ b/src/commands/PrototypeController.php
@@ -33,7 +33,7 @@ use yii\helpers\FileHelper;
 class PrototypeController extends Controller
 {
 
-    public $escapeFileNames = false;
+    public $escapeFileNames = true;
     public $exportPath = '@runtime/export';
 
     /**
@@ -57,17 +57,17 @@ class PrototypeController extends Controller
         $actions['export-html'] = [
             'class' => ExportAction::class,
             'modelClass' => Html::class,
-            'extention' => 'html',
+            'extension' => 'html',
         ];
         $actions['export-less'] = [
             'class' => ExportAction::class,
             'modelClass' => Less::class,
-            'extention' => 'less',
+            'extension' => 'less',
         ];
         $actions['export-twig'] = [
             'class' => ExportAction::class,
             'modelClass' => Twig::class,
-            'extention' => 'twig',
+            'extension' => 'twig',
         ];
         return $actions;
     }
@@ -77,7 +77,6 @@ class PrototypeController extends Controller
      *
      * Returns path alias if alias defined otherwise return plain path
      * Removes slash from end
-     * Add sub dir with name of extention
      */
     public function getExportPath()
     {


### PR DESCRIPTION
- filenames should be escaped per default
- if filename "looks" like a path, we must create subdirs
- TypoFix

Example before this fix:
- twig with key `en/site/index`

```
yii prototype/export-twig --exportPath=/app/project/resources/twig
Exporting twig files
..file_put_contents(/app/project/resources/twig/en/site/index.twig): failed to open stream: No such file or directory
```
